### PR TITLE
Make the crate executor independent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "hcsr04_async"
 version = "0.3.2"
 edition = "2021"
 license = "MIT"
-description = "A no-std driver for the HC-SR04 ultrasonic sensor using async and Embassy"
+description = "A no-std driver for the HC-SR04 ultrasonic sensor using async"
 categories = ["embedded", "no-std", "hardware-support"]
 keywords = ["async", "embassy", "embedded-hal", "hc-sr04"]
 readme = "README.md"
@@ -17,11 +17,11 @@ blocking_trigger = [
 ] # blocking trigger pulse, recommended for most use cases. Much more accurate trigger pulse length.
 
 [dependencies]
-embassy-time = "^0.4.0"
 embedded-hal-async = "^1.0.0"
 embedded-hal = "^1.0.0"
 defmt = "^0.3.8"
 libm = "^0.2.1"
+futures = { version = "0.3.31", default-features = false, features = [ "async-await" ] }
 
 [dev-dependencies]
 embedded-hal-async = "^1.0.0"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ The driver is designed to work with Celsius and Fahrenheit temperatures and cent
 
 Note that this only makes the blocking trigger pulse of 10us blocking, the remainder will still be async.
 
+- `embassy`: Initialize the sensor already setup for Embassy.
+
 ## Note
 
 Due to the non-blocking nature of this driver there is a probabiity that either the trigger pulse or the echo measurement get impacted by other async tasks. If this becomes a problem You must either use a blocking driver or You can attempt to run this driver in a higher priority task.

--- a/examples/src/bin/moving_average.rs
+++ b/examples/src/bin/moving_average.rs
@@ -16,8 +16,8 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_rp::gpio::{Input, Level, Output, Pull};
-use embassy_time::{Duration, Timer};
-use hcsr04_async::{Config, DistanceUnit, Hcsr04, TemperatureUnit};
+use embassy_time::{Delay, Duration, Instant, Timer};
+use hcsr04_async::{Config, DistanceUnit, Hcsr04, Now, TemperatureUnit};
 use {defmt_rtt as _, panic_probe as _};
 
 /// A simple moving average filter implementation with a fixed-size buffer.
@@ -73,7 +73,20 @@ async fn main(_spawner: Spawner) {
         temperature_unit: TemperatureUnit::Celsius,
     };
 
-    let mut sensor = Hcsr04::new(trigger, echo, config);
+    // Create clock function that returns microseconds
+    struct EmbassyClock;
+
+    impl Now for EmbassyClock {
+        fn now_micros(&self) -> u64 {
+            Instant::now().as_micros()
+        }
+    }
+
+    let clock = EmbassyClock;
+
+    let delay = Delay;
+
+    let mut sensor = Hcsr04::new(trigger, echo, config, clock, delay);
     let mut moving_average = MovingAverage::new();
 
     // The temperature of the environment, if known, can be used to adjust the speed of sound.


### PR DESCRIPTION
Through the use of `DelayNs` from `embedded-hal` and `embedded-hal-async`, plus an owned `Now` trait since there doesn't seem to be a standard for clocks, the crate can become independent from `embassy`.

This PR:

- Sets the `embassy-time` dependency as optional under an `embassy` flag, which provides a constructor already setup for `embassy`. This feature could be enabled by default to prevent breaking changes, it currently is not.
- Adds the `futures` crate to make use of `select_biased` macro, rather than `with_timeout`.
- Makes time management generic.
- Fixes clippy warnings for `if let Err(_)` statements and an unnecessary `()`.